### PR TITLE
Add stylus package, opt for non major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "@drewcovi",
   "license": "MIT",
   "dependencies": {
-    "broccoli-stylus-single": "^0.3.0"
+    "broccoli-stylus-single": "^0.3.0",
+    "stylus": "0.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
See details of why this change:
https://github.com/drewcovi/ember-cli-stylus/issues/2
