### PR TITLE
Set ext property

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var StylusCompiler = require('broccoli-stylus-single');
 
 function StylusPlugin(options) {
   this.name = 'ember-cli-stylus';
+  this.ext = 'styl';
   options = options || {};
   options.inputFile = options.inputFile || 'app.styl';
   options.outputFile = options.outputFile || 'app.css';


### PR DESCRIPTION
This was causing undefined to be registered as an extension for type 'css' which was causing errors when combined with [ember-component-css](https://github.com/ebryn/ember-component-css/pull/132).
