### PR TITLE
use setupPreprocessorRegistry

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,44 +1,58 @@
 var StylusCompiler = require('broccoli-stylus-single');
+var checker = require('ember-cli-version-checker');
 
-function StylusPlugin(options) {
+function StylusPlugin(optionsFn) {
   this.name = 'ember-cli-stylus';
   this.ext = 'styl';
-  options = options || {};
-  options.inputFile = options.inputFile || 'app.styl';
-  options.outputFile = options.outputFile || 'app.css';
-  if (options.sourceMap) {
-    options.sourceComments = 'map';
-    options.sourceMap = options.outputFile + '.map';
-  }
-  this.options = options;
+  this.optionsFn = optionsFn;
 };
 
 StylusPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
   var trees = [tree];
-  if (this.options.includePaths) trees = trees.concat(this.options.includePaths);
-  inputPath += '/' + this.options.inputFile;
-  outputPath += '/' + this.options.outputFile;
-  return new StylusCompiler(trees, inputPath, outputPath, this.options);
+  var options = this.optionsFn();
+  if (options.includePaths) trees = trees.concat(options.includePaths);
+  inputPath += '/' + options.inputFile;
+  outputPath += '/' + options.outputFile;
+  return new StylusCompiler(trees, inputPath, outputPath, options);
 };
 
-function EmberCLIStylus(project) {
-  this.project = project;
-  this.name = 'Ember CLI Stylus';
-}
+module.exports = {
+  name: 'Ember CLI Stylus',
 
-EmberCLIStylus.prototype.treeFor = function treeFor(type) {
-};
+  stylusOptions: function() {
+    var options = (this.app && this.app.options && this.app.options.stylusOptions) || {};
 
-EmberCLIStylus.prototype.included = function included(app) {
-  var options = app.options.stylusOptions || {};
-  if ((options.sourceMap === undefined) && (app.env == 'development')) {
-    options.sourcemap = {
-      inline: true
+    if (options.sourceMap) {
+      options.sourceComments = 'map';
+      options.sourceMap = options.outputFile + '.map';
+    }
+
+    if ((options.sourceMap === undefined) && (this.app.env == 'development')) {
+      options.sourcemap = {
+        inline: true
+      };
+      options.cache = false;
+    }
+
+    options.inputFile = options.inputFile || 'app.styl';
+    options.outputFile = options.outputFile || this.project.name() + '.css';
+    return options;
+  },
+
+  shouldSetupRegistryInIncluded: function() {
+    return !checker.isAbove(this, '0.2.0');
+  },
+
+  setupPreprocessorRegistry: function(type, registry) {
+    registry.add('css', new StylusPlugin(this.stylusOptions.bind(this)));
+  },
+
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+    this.app = app;
+
+    if (this.shouldSetupRegistryInIncluded()) {
+      this.setupPreprocessorRegistry('parent', app.registry);
     };
-    options.cache = false;
   }
-  options.outputFile = options.outputFile || this.project.name() + '.css';
-  app.registry.add('css', new StylusPlugin(options));
 };
-
-module.exports = EmberCLIStylus;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-stylus-single": "^1.0.0",
+    "ember-cli-version-checker": "^1.1.7",
     "stylus": "0.x"
   },
   "repository": {


### PR DESCRIPTION
Switch to using setupPreprocessorRegistry for [compatibility with ember-component-css](https://github.com/ebryn/ember-component-css/issues/178#issuecomment-257358035). Also convert to exporting a plain object so that the addon can automatically inherit from the [ember-cli addon class](https://ember-cli.com/api/classes/Addon.html#constructor-summary).