### PR TITLE
Add support for outputPaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install --save-dev ember-cli-stylus
 
 By default this addon will compile `app/styles/app.styl` into `dist/assets/app.css` and produce a sourceMap for your delectation.
 
-Or, if you want more control then you can specify options using the `stylusOptions` config property:
+Or, if you want more control then you can specify options using the `stylusOptions` config property in `ember-cli-build.js`
 
 ```javascript
 var app = new EmberApp({
@@ -23,11 +23,26 @@ var app = new EmberApp({
 });
 ```
 
-- `.inputFile`: the input Stylus file, defaults to `app.styl`
-- `.outputFile`: the output CSS file, defaults to `app.css`
 - `.includePaths`: an array of include paths
 - `.sourceMap`: controls sourcemap options, defaults to `inline: true` in development. The sourceMap file will be saved to `options.outputFile + '.map'`
 - `.use`: array with stylus plugins, check [stylus API](http://learnboost.github.io/stylus/docs/js.html#usefn)
+
+### Processing multiple files
+
+If you need to process multiple files, it can be done by [configuring the output paths](http://ember-cli.com/user-guide/#configuring-output-paths) in your `ember-cli-build.js`:
+
+```js
+var app = new EmberApp({
+  outputPaths: {
+    app: {
+      css: {
+        'app': '/assets/application-name.css',
+        'themes/alpha': '/assets/themes/alpha.css'
+      }
+    }
+  }
+});
+```
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var StylusCompiler = require('broccoli-stylus-single');
+var path = require('path');
 var checker = require('ember-cli-version-checker');
+var mergeTrees = require('broccoli-merge-trees');
 
 function StylusPlugin(optionsFn) {
   this.name = 'ember-cli-stylus';
@@ -7,13 +9,22 @@ function StylusPlugin(optionsFn) {
   this.optionsFn = optionsFn;
 };
 
-StylusPlugin.prototype.toTree = function(tree, inputPath, outputPath) {
+StylusPlugin.prototype.toTree = function(tree, inputPath, outputPath, inputOptions) {
   var trees = [tree];
-  var options = this.optionsFn();
-  if (options.includePaths) trees = trees.concat(options.includePaths);
-  inputPath += '/' + options.inputFile;
-  outputPath += '/' + options.outputFile;
-  return new StylusCompiler(trees, inputPath, outputPath, options);
+  var options = Object.assign({}, this.optionsFn(), inputOptions);
+
+  if (options.includePaths) {
+    trees = trees.concat(options.includePaths);
+  }
+
+  var paths = options.outputPaths;
+  var trees = Object.keys(paths).map(function(file) {
+    var input = path.join(inputPath, file + '.styl');
+    var output = paths[file];
+    return new StylusCompiler(trees, input, output, options);
+  });
+
+  return mergeTrees(trees);
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "@drewcovi",
   "license": "MIT",
   "dependencies": {
+    "broccoli-merge-trees": "^2.0.0",
     "broccoli-stylus-single": "^1.0.0",
     "ember-cli-version-checker": "^1.1.7",
     "stylus": "0.x"


### PR DESCRIPTION
This addon does not reflect `outputPaths` option that can be specific in `ember-cli-build.js` file.

ember-cli guide: https://ember-cli.com/user-guide/#configuring-output-paths

Change in ember-cli-sass addon that adds support for `outputPaths` (the addon was used for inspiration according to README.md): https://github.com/aexmachina/ember-cli-sass/commit/c9f9c768153e429b6a1108001ca0a9463d048c2d