### PR TITLE
Bump ember-cli-dependency-checker to version 2.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var StylusCompiler = require('broccoli-stylus-single');
 var path = require('path');
-var checker = require('ember-cli-version-checker');
+var VersionChecker = require('ember-cli-version-checker');
 var mergeTrees = require('broccoli-merge-trees');
 
 function StylusPlugin(optionsFn) {
@@ -51,7 +51,10 @@ module.exports = {
   },
 
   shouldSetupRegistryInIncluded: function() {
-    return !checker.isAbove(this, '0.2.0');
+    var checker = new VersionChecker(this);
+    var emberVersion = checker.forEmber();
+
+    return !emberVersion.gt('0.2.0');
   },
 
   setupPreprocessorRegistry: function(type, registry) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-stylus-single": "^1.0.0",
-    "ember-cli-version-checker": "^1.1.7",
+    "ember-cli-version-checker": "^2.0.0",
     "stylus": "0.x"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,21 +1,19 @@
 {
   "name": "ember-cli-stylus",
   "version": "1.0.6",
-  "description": "Use node-stylus to preprocess your ember-cli app's files, with support for sourceMaps and include paths",
+  "description":
+    "Use node-stylus to preprocess your ember-cli app's files, with support for sourceMaps and include paths",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [
-    "ember-addon",
-    "sass"
-  ],
+  "keywords": ["ember-addon", "sass"],
   "author": "@drewcovi",
   "license": "MIT",
   "dependencies": {
     "broccoli-merge-trees": "^2.0.0",
-    "broccoli-stylus-single": "^1.0.0",
-    "ember-cli-version-checker": "^2.0.0",
+    "broccoli-stylus-single": "^1.0.1",
+    "ember-cli-version-checker": "^2.1.0",
     "stylus": "0.x"
   },
   "repository": {


### PR DESCRIPTION
Fix `DEPRECATION: An addon is trying to access project.nodeModulesPath. This is not a reliable way to discover npm modules. Instead, consider doing: require("resolve").sync(something, { basedir: project.root }).`